### PR TITLE
Feature/version from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpx-smoother-vue",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -155,10 +155,13 @@
 
     .slope-label
       margin-right: 16px
+      line-height: 24px
 
+    // The legend fits into the width and height or it's container, so they must be specified
     .slope-colormap
       width: 200px
-      align-self: center
+      height: 40px
+      margin-top: 6px
       margin-right: 20px
 
     .key path

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -2,7 +2,7 @@
   <div>
      <v-app-bar dark color="primary">
        <v-toolbar-items>
-         <v-btn text to="/">GPX Smoother Version 1.0</v-btn>
+         <v-btn text to="/">GPX Smoother Version {{appVersion}}</v-btn>
        </v-toolbar-items>
       <v-spacer/>
       <v-toolbar-items>
@@ -14,8 +14,11 @@
 </template>
 
 <script>
+  import {mapState} from 'vuex';
+
   export default {
-    name: 'Toolbar'
+    name: 'Toolbar',
+    computed: mapState(['appVersion']),
   };
 </script>
 

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -12,6 +12,7 @@ Vue.use(Vuex);
 
 const getDefaultState = () => {
   return {
+    appVersion: process.env.VUE_APP_VERSION || 0,
     isLoading: false,
     loadError: null,
     fileJson: null,

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -32,7 +32,10 @@
           decreased by a fixed percentage.</li>
       <li>Added the display of average slope for original and smoothed data.</li>
     </ul>
-
+    <h3>Version 1.2.0</h3>
+    <ul>
+      <li>Load the application version from the package.json at build time.</li>
+    </ul>
   </div>
 
 </template>

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -35,6 +35,8 @@
     <h3>Version 1.2.0</h3>
     <ul>
       <li>Load the application version from the package.json at build time.</li>
+      <li>Fixed an issue where the slope legend was throwing an error because the height was not initialized
+          correctly.</li>
     </ul>
   </div>
 

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,4 @@
+process.env.VUE_APP_VERSION = require('./package.json').version;
 module.exports = {
   'transpileDependencies': [
     'vuetify'


### PR DESCRIPTION
Load the application version from the package.json at build time.
Fixed an issue where the slope legend was throwing an error because the height was not initialized correctly.
