### PR TITLE
Maintain start and end point elevations during smoothing operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpx-smoother-vue",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -97,7 +97,7 @@ export default new Vuex.Store({
       const selection = sel2idx(toSmooth, operation.selection[0], operation.selection[1]);
       function postProcess(result) {
         if (operation.maintainElevations) {
-          return restoreAscentDescentSection(result.smoothedValues, toSmooth, selection.startIdx, selection.stopIdx);
+          return restoreAscentDescentSection(result.smoothedValues, toSmooth, selection);
         } else {
           return result;
         }

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -10,7 +10,8 @@ import {shiftSlope} from '@/utilities/shiftSlope';
 import {kalmanFilter} from '@/utilities/kalmanFilter';
 import {slopeSmoothing} from '@/utilities/slopeSmoothing';
 import {updateTimeIntervals} from '@/utilities/updateTimeIntervals';
-import {restoreAscentDescent} from '@/utilities//restoreAscentDescent';
+import {restoreAscentDescentSection} from '@/utilities/restoreAscentDescent';
+import {sel2idx} from '@/utilities/sel2idx';
 
 Vue.use(Vuex);
 
@@ -93,30 +94,38 @@ export default new Vuex.Store({
         return;
       }
       const toSmooth = context.state.smoothedValues ? context.state.smoothedValues : context.state.rawValues;
+      const selection = sel2idx(toSmooth, operation.selection[0], operation.selection[1]);
+      function postProcess(result) {
+        if (operation.maintainElevations) {
+          return restoreAscentDescentSection(result.smoothedValues, toSmooth, selection.startIdx, selection.stopIdx);
+        } else {
+          return result;
+        }
+      }
       let smoothedValues;
       switch (operation.name) {
         case 'smooth': {
-          smoothedValues = boxSmoothing(toSmooth, operation.numberOfPoints, operation.selection);
+          smoothedValues = postProcess(boxSmoothing(toSmooth, operation.numberOfPoints, selection));
           break;
         }
         case 'smoothSlope': {
-          smoothedValues = slopeSmoothing(toSmooth, operation.numberOfPoints, operation.selection);
+          smoothedValues = postProcess(slopeSmoothing(toSmooth, operation.numberOfPoints, selection));
           break;
         }
         case 'savitzkyGolay': {
-          smoothedValues = savitzkyGolay(toSmooth, operation, operation.selection);
+          smoothedValues = postProcess(savitzkyGolay(toSmooth, operation, selection));
           break;
         }
         case 'kalmanFilter': {
-          smoothedValues = kalmanFilter(toSmooth, operation, operation.selection);
+          smoothedValues = postProcess(kalmanFilter(toSmooth, operation, selection));
           break;
         }
         case 'slopeRange': {
-          smoothedValues = setSlopeRange(toSmooth, operation.range, operation.selection);
+          smoothedValues = postProcess(setSlopeRange(toSmooth, operation.range, selection));
           break;
         }
         case 'flatten': {
-          smoothedValues = flattenPoints(toSmooth, operation.slopeDelta, operation.selection);
+          smoothedValues = postProcess(flattenPoints(toSmooth, operation.slopeDelta, selection));
           break;
         }
         case 'slopePercentage': {
@@ -125,10 +134,6 @@ export default new Vuex.Store({
         }
         case 'elevate': {
           smoothedValues = elevatePoints(toSmooth, operation.metres, operation.selection);
-          break;
-        }
-        case 'restoreAscentDescent': {
-          smoothedValues = restoreAscentDescent(toSmooth, context.state.rawValues);
           break;
         }
         case 'updateTimeIntervals': {

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -10,6 +10,7 @@ import {shiftSlope} from '@/utilities/shiftSlope';
 import {kalmanFilter} from '@/utilities/kalmanFilter';
 import {slopeSmoothing} from '@/utilities/slopeSmoothing';
 import {updateTimeIntervals} from '@/utilities/updateTimeIntervals';
+import {restoreAscentDescent} from '@/utilities//restoreAscentDescent';
 
 Vue.use(Vuex);
 
@@ -124,6 +125,10 @@ export default new Vuex.Store({
         }
         case 'elevate': {
           smoothedValues = elevatePoints(toSmooth, operation.metres, operation.selection);
+          break;
+        }
+        case 'restoreAscentDescent': {
+          smoothedValues = restoreAscentDescent(toSmooth, context.state.rawValues);
           break;
         }
         case 'updateTimeIntervals': {

--- a/src/utilities/boxSmoothing.js
+++ b/src/utilities/boxSmoothing.js
@@ -1,6 +1,6 @@
 import {averageSlopeFromTotal} from './displayFormat';
 
-export function boxSmoothing(values, numPoints, selected) {
+export function boxSmoothing(values, numPoints, selection) {
   const dataLength = values.length;
   if (dataLength === 0) {
     return [];
@@ -10,9 +10,6 @@ export function boxSmoothing(values, numPoints, selected) {
     smoothingSize = 2;
   }
   const toSmooth = values;
-  const startDistance = selected[0];
-  const endDistance = selected[1];
-  let distance = 0;
   let newElevations = [];
   for (let i = 0; i < dataLength; i++) {
     let sumValues = 0;
@@ -36,8 +33,7 @@ export function boxSmoothing(values, numPoints, selected) {
     let point = {
       ...toSmooth[i]
     };
-    distance = distance + point.distance;
-    if (distance >= startDistance && distance <= endDistance) {
+    if (i >= selection.startIdx && i <= selection.stopIdx) {
       point.ele = newElevations[i];
       point.slope = 0;
       if (previous && point.distance) {
@@ -50,8 +46,7 @@ export function boxSmoothing(values, numPoints, selected) {
   }
 
   return {
-    smoothedValues,
+    smoothedValues: smoothedValues,
     averageSlope: averageSlopeFromTotal(totalSlope, dataLength)
   };
-
 }

--- a/src/utilities/elevatePoints.js
+++ b/src/utilities/elevatePoints.js
@@ -21,7 +21,7 @@ export function elevatePoints(toElevate, metres, selected) {
     smoothedValues.push(point);
   }
   return {
-    smoothedValues,
+    smoothedValues: smoothedValues,
     averageSlope: averageSlopeFromTotal(totalSlope, dataLength)
   };
 }

--- a/src/utilities/flattenPoints.js
+++ b/src/utilities/flattenPoints.js
@@ -1,6 +1,6 @@
 import {averageSlopeFromTotal} from './displayFormat';
 
-export function flattenPoints(toFlatten, maxSlope, selected) {
+export function flattenPoints(toFlatten, maxSlope, selection) {
   const dataLength = toFlatten.length;
   if (dataLength === 0)
     return;
@@ -8,16 +8,12 @@ export function flattenPoints(toFlatten, maxSlope, selected) {
   const maxDelta = Math.abs(Number(maxSlope)) / 100;
   let previous = null;
   let totalSlope = 0;
-  const startDistance = selected[0];
-  const endDistance = selected[1];
-  let distance = 0;
   for (let i = 0; i < dataLength; i++) {
     let point = {
       ...toFlatten[i]
     };
     if (previous) {
-      distance = distance + point.distance;
-      if (distance >= startDistance && distance <= endDistance) {
+      if (i >= selection.startIdx && i <= selection.stopIdx) {
         let deltaSlope = point.slope - previous.slope;
         if (Math.abs(deltaSlope) > maxDelta) {
           if (deltaSlope > 0) {
@@ -34,7 +30,7 @@ export function flattenPoints(toFlatten, maxSlope, selected) {
     previous = point;
   }
   return {
-    smoothedValues,
+    smoothedValues: smoothedValues,
     averageSlope: averageSlopeFromTotal(totalSlope, dataLength)
   };
 }

--- a/src/utilities/kalmanFilter.js
+++ b/src/utilities/kalmanFilter.js
@@ -1,5 +1,4 @@
 import {averageSlopeFromTotal} from './displayFormat';
-import {restoreAscentDescentSection} from './restoreAscentDescent';
 
 export function kalmanFilter(toSmooth, options, selected) {
   let KalmanFilter = require('kalmanjs');
@@ -10,22 +9,12 @@ export function kalmanFilter(toSmooth, options, selected) {
   const smoothedValues = [];
   let previous = null;
   let totalSlope = 0;
-  const startDistance = selected[0];
-  const endDistance = selected[1];
-  let distance = 0;
-  let startidx = 0;
-  let stopidx = dataLength - 1;
   for (let i = 0; i < dataLength; i++) {
     let point = {
       ...toSmooth[i]
     };
     if (previous) {
-      distance = distance + point.distance;
-      if (distance >= startDistance && distance <= endDistance) {
-        if (startidx === 0) {
-          startidx = i;
-        }
-        stopidx = i;
+      if (i >= selected.startIdx && i <= selected.stopIdx) {
         if (options.useDeltaSlope) {
           let deltaSlope = point.slope - previous.slope;
           point.slope = kf.filter(deltaSlope);
@@ -39,9 +28,8 @@ export function kalmanFilter(toSmooth, options, selected) {
     smoothedValues.push(point);
     previous = point;
   }
-  const restored = restoreAscentDescentSection(smoothedValues, toSmooth, startidx, stopidx);
   return {
-    smoothedValues: restored.smoothedValues,
+    smoothedValues: smoothedValues,
     averageSlope: averageSlopeFromTotal(totalSlope, dataLength)
   };
 }

--- a/src/utilities/kalmanFilter.js
+++ b/src/utilities/kalmanFilter.js
@@ -1,4 +1,5 @@
 import {averageSlopeFromTotal} from './displayFormat';
+import {restoreAscentDescentSection} from './restoreAscentDescent';
 
 export function kalmanFilter(toSmooth, options, selected) {
   let KalmanFilter = require('kalmanjs');
@@ -12,6 +13,8 @@ export function kalmanFilter(toSmooth, options, selected) {
   const startDistance = selected[0];
   const endDistance = selected[1];
   let distance = 0;
+  let startidx = 0;
+  let stopidx = dataLength - 1;
   for (let i = 0; i < dataLength; i++) {
     let point = {
       ...toSmooth[i]
@@ -19,6 +22,10 @@ export function kalmanFilter(toSmooth, options, selected) {
     if (previous) {
       distance = distance + point.distance;
       if (distance >= startDistance && distance <= endDistance) {
+        if (startidx === 0) {
+          startidx = i;
+        }
+        stopidx = i;
         if (options.useDeltaSlope) {
           let deltaSlope = point.slope - previous.slope;
           point.slope = kf.filter(deltaSlope);
@@ -32,8 +39,9 @@ export function kalmanFilter(toSmooth, options, selected) {
     smoothedValues.push(point);
     previous = point;
   }
+  const restored = restoreAscentDescentSection(smoothedValues, toSmooth, startidx, stopidx);
   return {
-    smoothedValues,
+    smoothedValues: restored.smoothedValues,
     averageSlope: averageSlopeFromTotal(totalSlope, dataLength)
   };
 }

--- a/src/utilities/restoreAscentDescent.js
+++ b/src/utilities/restoreAscentDescent.js
@@ -1,11 +1,11 @@
 import {averageSlopeFromTotal} from './displayFormat';
 
-export function restoreAscentDescentSection(toRestore, rawValues, startidx, stopidx)
+export function restoreAscentDescentSection(modValues, srcValues, selection)
 {
-  const section = restoreAscentDescent(toRestore.slice(startidx, stopidx),
-                                       rawValues.slice(startidx, stopidx));
-  let restored = rawValues.slice();
-  restored.splice(startidx, section.smoothedValues.length, ...section.smoothedValues);
+  const section = restoreAscentDescent(modValues.slice(selection.startIdx, selection.stopIdx),
+                                       srcValues.slice(selection.startIdx, selection.stopIdx));
+  let restored = srcValues.slice();
+  restored.splice(selection.startIdx, section.smoothedValues.length, ...section.smoothedValues);
 
   let totalSlope = 0;
   restored.forEach( point => {
@@ -14,7 +14,7 @@ export function restoreAscentDescentSection(toRestore, rawValues, startidx, stop
 
   return {
     smoothedValues: restored,
-    averageSlope: averageSlopeFromTotal(totalSlope, toRestore.length)
+    averageSlope: averageSlopeFromTotal(totalSlope, modValues.length)
   };
 }
 

--- a/src/utilities/restoreAscentDescent.js
+++ b/src/utilities/restoreAscentDescent.js
@@ -1,5 +1,22 @@
 import {averageSlopeFromTotal} from './displayFormat';
 
+export function restoreAscentDescentSection(toRestore, rawValues, startidx, stopidx) {
+  const section = restoreAscentDescent(toRestore.slice(startidx, stopidx),
+                                       rawValues.slice(startidx, stopidx));
+  let restored = rawValues.slice();
+  restored.splice(startidx, section.smoothedValues.length, ...section.smoothedValues);
+
+  let totalSlope = 0;
+  restored.forEach( point => {
+    totalSlope += point.slope;
+  });
+
+  return {
+    smoothedValues: restored,
+    averageSlope: averageSlopeFromTotal(totalSlope, toRestore.length)
+  };
+}
+
 export function restoreAscentDescent(toRestore, rawValues) {
 
     const dataLength = toRestore.length;

--- a/src/utilities/restoreAscentDescent.js
+++ b/src/utilities/restoreAscentDescent.js
@@ -1,0 +1,53 @@
+import {averageSlopeFromTotal} from './displayFormat';
+
+export function restoreAscentDescent(toRestore, rawValues) {
+
+    const dataLength = toRestore.length;
+    if (rawValues.length === 0 ||
+        toRestore.length === 0 ||
+        toRestore.length != dataLength) {
+      return;
+    }
+
+    var distanceRaw = 0;
+    for (var i = 0; i < dataLength; i++) {
+      distanceRaw += rawValues[i].distance;
+    }
+
+    const rawB = rawValues[0];
+    const rawE = rawValues[dataLength - 1];
+    const smoothB = toRestore[0];
+    const smoothE = toRestore[dataLength - 1];
+
+    const startOff = rawB.ele - smoothB.ele;
+    const endOff = rawE.ele - smoothE.ele;
+    const slopeComp = (endOff - startOff) / distanceRaw;
+
+    const restoredAscentVals = [];
+    let totalSlope = 0;
+    let dist = 0;
+    let previous = null;
+    for (i = 0; i < dataLength; i++) {
+      let point =  {
+        ...toRestore[i]
+      };
+      if (previous) {
+        point.slope = 0;
+        if (point.distance) {
+          dist += point.distance;
+          point.ele += dist * slopeComp + startOff;
+          point.slope = (point.ele - previous.ele) / point.distance;
+        }
+      } else {
+        point.ele += startOff;
+      }
+      restoredAscentVals.push(point);
+      previous = point;
+      totalSlope += point.slope;
+    }
+
+    return {
+      smoothedValues: restoredAscentVals,
+      averageSlope: averageSlopeFromTotal(totalSlope, dataLength)
+    };
+}

--- a/src/utilities/restoreAscentDescent.js
+++ b/src/utilities/restoreAscentDescent.js
@@ -18,54 +18,50 @@ export function restoreAscentDescentSection(toRestore, rawValues, startidx, stop
   };
 }
 
-function restoreAscentDescent(toRestore, rawValues)
+function restoreAscentDescent(modValues, srcValues)
 {
-    const dataLength = toRestore.length;
-    if (rawValues.length === 0 ||
-        toRestore.length === 0 ||
-        toRestore.length != dataLength) {
+    const L = modValues.length;
+    if (srcValues.length === 0 ||
+        modValues.length === 0 ||
+        modValues.length != srcValues.length) {
       return;
     }
 
-    var distanceRaw = 0;
-    for (var i = 0; i < dataLength; i++) {
-      distanceRaw += rawValues[i].distance;
-    }
+    var totalDistance = 0;
+    srcValues.forEach(point => {
+      totalDistance += point.distance;
+    });
 
-    const rawB = rawValues[0];
-    const rawE = rawValues[dataLength - 1];
-    const smoothB = toRestore[0];
-    const smoothE = toRestore[dataLength - 1];
+    const srcStartPoint = srcValues[0];
+    const srcEndPoint = srcValues[L - 1];
+    const modStartPoint = modValues[0];
+    const modEndPoint = modValues[L - 1];
 
-    const startOff = rawB.ele - smoothB.ele;
-    const endOff = rawE.ele - smoothE.ele;
-    const slopeComp = (endOff - startOff) / distanceRaw;
+    const startVOffset = srcStartPoint.ele - modStartPoint.ele;
+    const endVOffset = srcEndPoint.ele - modEndPoint.ele;
+    const slopeComp = (endVOffset - startVOffset) / totalDistance;
 
-    const restoredAscentVals = [];
     let totalSlope = 0;
     let dist = 0;
     let previous = null;
-    for (i = 0; i < dataLength; i++) {
-      let point =  {
-        ...toRestore[i]
-      };
+    const compensatedValues = modValues.slice();
+    compensatedValues.forEach(point => {
       if (previous) {
         point.slope = 0;
         if (point.distance) {
           dist += point.distance;
-          point.ele += dist * slopeComp + startOff;
+          point.ele += dist * slopeComp + startVOffset;
           point.slope = (point.ele - previous.ele) / point.distance;
         }
       } else {
-        point.ele += startOff;
+        point.ele += startVOffset;
       }
-      restoredAscentVals.push(point);
       previous = point;
       totalSlope += point.slope;
-    }
+    });
 
     return {
-      smoothedValues: restoredAscentVals,
-      averageSlope: averageSlopeFromTotal(totalSlope, dataLength)
+      smoothedValues: compensatedValues,
+      averageSlope: averageSlopeFromTotal(totalSlope, L)
     };
 }

--- a/src/utilities/restoreAscentDescent.js
+++ b/src/utilities/restoreAscentDescent.js
@@ -1,6 +1,7 @@
 import {averageSlopeFromTotal} from './displayFormat';
 
-export function restoreAscentDescentSection(toRestore, rawValues, startidx, stopidx) {
+export function restoreAscentDescentSection(toRestore, rawValues, startidx, stopidx)
+{
   const section = restoreAscentDescent(toRestore.slice(startidx, stopidx),
                                        rawValues.slice(startidx, stopidx));
   let restored = rawValues.slice();
@@ -17,8 +18,8 @@ export function restoreAscentDescentSection(toRestore, rawValues, startidx, stop
   };
 }
 
-export function restoreAscentDescent(toRestore, rawValues) {
-
+function restoreAscentDescent(toRestore, rawValues)
+{
     const dataLength = toRestore.length;
     if (rawValues.length === 0 ||
         toRestore.length === 0 ||

--- a/src/utilities/savitzkyGolay.js
+++ b/src/utilities/savitzkyGolay.js
@@ -1,13 +1,11 @@
 import {averageSlopeFromTotal} from './displayFormat';
 
-export function savitzkyGolay(toSmooth, options, selected) {
+export function savitzkyGolay(toSmooth, options, selection) {
   const dataLength = toSmooth.length;
   if (dataLength === 0) {
     return [];
   }
 
-  const startDistance = selected[0];
-  const endDistance = selected[1];
   let distance = 0;
   const xValues = [];
   const yValues = [];
@@ -15,12 +13,13 @@ export function savitzkyGolay(toSmooth, options, selected) {
   // Collect the x and y values to be smoothed
   for (let i = 0; i < dataLength; i++) {
     const point = toSmooth[i];
-    if (distance >= startDistance && distance <= endDistance) {
+    if (i >= selection.startIdx && i <= selection.stopIdx) {
       xValues.push(distance);
       yValues.push(point.ele);
     }
+    // ucf: sure this computation after pushing x?
     distance =  distance + point.distance;
-    if (distance > endDistance) {
+    if (i > selection.stopIdx) {
       break;
     }
   }
@@ -35,27 +34,25 @@ export function savitzkyGolay(toSmooth, options, selected) {
   let smoothedValues = [];
   let previous = null;
   let totalSlope = 0;
-  distance = 0;
   let newValueIndex = 0;
   for (let i = 0; i < dataLength; i++) {
     let point = {
       ...toSmooth[i]
     };
-    if (distance >= startDistance && distance <= endDistance) {
+    if (i >= selection.startIdx && i <= selection.stopIdx) {
       point.ele = newValues[newValueIndex++];
       point.slope = 0;
       if (previous && point.distance) {
         point.slope = (point.ele - previous.ele) / point.distance;
       }
     }
-    distance = distance + point.distance;
     smoothedValues.push(point);
     previous = point;
     totalSlope = totalSlope + point.slope;
   }
 
   return {
-    smoothedValues,
+    smoothedValues: smoothedValues,
     averageSlope: averageSlopeFromTotal(totalSlope, dataLength)
   };
 

--- a/src/utilities/sel2idx.js
+++ b/src/utilities/sel2idx.js
@@ -1,0 +1,24 @@
+
+export function sel2idx(values, selectionStartDist, selectionEndDist)
+{
+  let i = 0;
+  let distance = 0;
+  let startidx = 0;
+  let stopidx = values.length - 1;
+  values.forEach(point => {
+    distance = distance + point.distance;
+    if (distance >= selectionStartDist &&
+        distance <= selectionEndDist)
+    {
+      if (startidx === 0) {
+        startidx = i;
+      }
+      stopidx = i;
+    }
+    i++;
+  });
+  return {
+    startIdx: startidx,
+    stopIdx: stopidx
+  };
+}

--- a/src/utilities/setSlopeRange.js
+++ b/src/utilities/setSlopeRange.js
@@ -1,4 +1,5 @@
 import {averageSlopeFromTotal} from './displayFormat';
+import {restoreAscentDescentSection} from './restoreAscentDescent';
 
 export function setSlopeRange(toFlatten, range, selection) {
   const dataLength = toFlatten.length;
@@ -13,6 +14,8 @@ export function setSlopeRange(toFlatten, range, selection) {
   let distance = 0;
   let previous = null;
   let totalSlope = 0;
+  let startidx = 0;
+  let stopidx = dataLength - 1;
   for (let i = 0; i < dataLength; i++) {
     let point = {
       ...toFlatten[i]
@@ -21,6 +24,10 @@ export function setSlopeRange(toFlatten, range, selection) {
       let slope = toFlatten[i].slope;
       distance = distance + point.distance;
       if (distance >= startDistance && distance <= endDistance) {
+        if (startidx === 0) {
+          startidx = i;
+        }
+        stopidx = i;
         if (slope > maxSlope) {
           slope = maxSlope;
         } else if (slope < minSlope) {
@@ -34,8 +41,9 @@ export function setSlopeRange(toFlatten, range, selection) {
     smoothedValues.push(point);
     previous = point;
   }
+  const restored = restoreAscentDescentSection(smoothedValues, toFlatten, startidx, stopidx);
   return {
-    smoothedValues,
+    smoothedValues: restored.smoothedValues,
     averageSlope: averageSlopeFromTotal(totalSlope, dataLength)
   };
 }

--- a/src/utilities/setSlopeRange.js
+++ b/src/utilities/setSlopeRange.js
@@ -1,5 +1,4 @@
 import {averageSlopeFromTotal} from './displayFormat';
-import {restoreAscentDescentSection} from './restoreAscentDescent';
 
 export function setSlopeRange(toFlatten, range, selection) {
   const dataLength = toFlatten.length;
@@ -9,25 +8,15 @@ export function setSlopeRange(toFlatten, range, selection) {
   var smoothedValues = [];
   var maxSlope = Number(range.maxSlope) / 100;
   var minSlope = Number(range.minSlope) / 100;
-  let startDistance = selection[0];
-  let endDistance = selection[1];
-  let distance = 0;
   let previous = null;
   let totalSlope = 0;
-  let startidx = 0;
-  let stopidx = dataLength - 1;
   for (let i = 0; i < dataLength; i++) {
     let point = {
       ...toFlatten[i]
     };
     if (previous) {
       let slope = toFlatten[i].slope;
-      distance = distance + point.distance;
-      if (distance >= startDistance && distance <= endDistance) {
-        if (startidx === 0) {
-          startidx = i;
-        }
-        stopidx = i;
+      if (i >= selection.startIdx && i <= selection.stopIdx) {
         if (slope > maxSlope) {
           slope = maxSlope;
         } else if (slope < minSlope) {
@@ -41,9 +30,8 @@ export function setSlopeRange(toFlatten, range, selection) {
     smoothedValues.push(point);
     previous = point;
   }
-  const restored = restoreAscentDescentSection(smoothedValues, toFlatten, startidx, stopidx);
   return {
-    smoothedValues: restored.smoothedValues,
+    smoothedValues: smoothedValues,
     averageSlope: averageSlopeFromTotal(totalSlope, dataLength)
   };
 }

--- a/src/utilities/slopeSmoothing.js
+++ b/src/utilities/slopeSmoothing.js
@@ -1,6 +1,6 @@
 import {averageSlopeFromTotal} from './displayFormat';
 
-export function slopeSmoothing(values, numPoints, selected) {
+export function slopeSmoothing(values, numPoints, selection) {
   const dataLength = values.length;
   if (dataLength === 0) {
     return [];
@@ -10,9 +10,7 @@ export function slopeSmoothing(values, numPoints, selected) {
     smoothingSize = 2;
   }
   const toSmooth = values;
-  const startDistance = selected[0];
-  const endDistance = selected[1];
-  let distance = 0;
+//  let distance = 0;
   let newSlopes = [];
 
   for (let i = 0; i < dataLength; i++) {
@@ -37,8 +35,7 @@ export function slopeSmoothing(values, numPoints, selected) {
     let point = {
       ...toSmooth[i]
     };
-    distance = distance + point.distance;
-    if (distance >= startDistance && distance <= endDistance && i > 0) {
+    if (i >= selection.startIdx && i <= selection.stopIdx && i > 0) {
       point.slope = newSlopes[i];
       point.ele = (point.slope * point.distance) + previous.ele;
     }
@@ -48,7 +45,7 @@ export function slopeSmoothing(values, numPoints, selected) {
   }
 
   return {
-    smoothedValues,
+    smoothedValues: smoothedValues,
     averageSlope: averageSlopeFromTotal(totalSlope, dataLength)
   };
 

--- a/src/utilities/updateTimeIntervals.js
+++ b/src/utilities/updateTimeIntervals.js
@@ -25,7 +25,7 @@ export function updateTimeIntervals(toUpdate, timeShift, averageSlope) {
     smoothedValues.push(point);
   }
   return {
-    smoothedValues,
+    smoothedValues: smoothedValues,
     averageSlope: averageSlope
   };
 }

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -4,7 +4,7 @@
     <p>
       The GPX Smoother lets you load a GPX file, and smooth out the elevation, to make it easier to ride in your
       favourite trainer software.
-    <p/>
+    </p>
 
     <h2>Smoothing</h2>
     <p>
@@ -22,7 +22,12 @@
     </ul>
 
     <p>The <span class="font-weight-bold">One Second Time Intervals</span> button will add a time stamp to each track point, and each time stamp
-       will be one second from the previous time stamp.  Percentage time shift will speed up or slow down the time intervals accordingly.</p>
+       will be one second from the previous time stamp.  Percentage time shift will speed up or slow down the time intervals accordingly.
+    </p>
+    <p>
+      When the <span class="font-weight-bold">Maintain start/end elevations</span> check box is checked, the track is readjusted after the smoothing algorithm such that the original
+      elevations at the start and end point of the current selection are maintained. Note that this can slightly alter the gradients.
+    </p>
     <p>
       Slide the <span class="font-weight-bold">triangular handles</span> on the smaller graph to select only a portion of the ride to smooth.
     </p>
@@ -65,6 +70,11 @@
     </ul>
 
     <h2 class="change-log">Change Log</h2>
+
+    <h3>Version 1.11.0 - 2026-01-17</h3>
+    <ul>
+      <li>Add a post processing option to maintain start and end point elevations during smoothing operations.</li>
+    </ul>
 
     <h3>Version 1.10.0 - 2022-04-09</h3>
     <ul>

--- a/src/views/GpxSmoother.vue
+++ b/src/views/GpxSmoother.vue
@@ -133,6 +133,13 @@
             v-model.number="timeShift"
         />
       </div>
+      <div class="input-row">
+        <v-btn
+            @click="onRestoreAscentDescent"
+            :disabled="!canSmooth">
+            Restore total ascent descent
+        </v-btn>
+      </div>
       <v-btn
         @click="onResetData"
         :disabled="!canSmooth">
@@ -268,6 +275,9 @@ export default {
     },
     onUpdateTimeIntervals() {
       this.addOperation('updateTimeIntervals', {timeShift: this.timeShift});
+    },
+    onRestoreAscentDescent() {
+      this.addOperation('restoreAscentDescent');
     },
     onResetData() {
       store.dispatch('resetSmoothing');

--- a/src/views/GpxSmoother.vue
+++ b/src/views/GpxSmoother.vue
@@ -343,7 +343,7 @@ export default {
     .v-input__slot
       max-width: 600px
 
-  .save  .smoothing-algorithms
+  .smoothing-algorithms
     margin-left: 30px
 
 </style>

--- a/src/views/GpxSmoother.vue
+++ b/src/views/GpxSmoother.vue
@@ -14,6 +14,10 @@
     </div>
     <div class="instruct">2. Click on an apply button to select the type of smoothing:</div>
     <div class="smoother-input">
+        <v-checkbox
+          label="Maintain elevation of start and end points"
+          v-model="maintainElevations"
+        ></v-checkbox>
       <div class="input-row">
         <v-btn
           @click="onSlopeSmoothing"
@@ -133,13 +137,6 @@
             v-model.number="timeShift"
         />
       </div>
-      <div class="input-row">
-        <v-btn
-            @click="onRestoreAscentDescent"
-            :disabled="!canSmooth">
-            Restore total ascent descent
-        </v-btn>
-      </div>
       <v-btn
         @click="onResetData"
         :disabled="!canSmooth">
@@ -207,6 +204,7 @@ export default {
     kalmanQ: 3,
     timeShift: 100,
     useDeltaSlope: false,
+    maintainElevations: true,
     gpxFileName: 'smoother.gpx',
     gpxName: '',
     gpxDescription: '',
@@ -244,6 +242,7 @@ export default {
         name,
         ...parameters,
         selection: this.selection,
+        maintainElevations: this.maintainElevations,
         enabled: true,
         id: generateUUID()
       });
@@ -275,9 +274,6 @@ export default {
     },
     onUpdateTimeIntervals() {
       this.addOperation('updateTimeIntervals', {timeShift: this.timeShift});
-    },
-    onRestoreAscentDescent() {
-      this.addOperation('restoreAscentDescent');
     },
     onResetData() {
       store.dispatch('resetSmoothing');

--- a/src/views/GpxSmoother.vue
+++ b/src/views/GpxSmoother.vue
@@ -14,95 +14,97 @@
     </div>
     <div class="instruct">2. Click on an apply button to select the type of smoothing:</div>
     <div class="smoother-input">
+      <div class="smoothing-algorithms">
         <v-checkbox
-          label="Maintain elevation of start and end points"
+          label="Maintain start/end elevations"
           v-model="maintainElevations"
         ></v-checkbox>
-      <div class="input-row">
-        <v-btn
-          @click="onSlopeSmoothing"
-          :disabled="!canSmooth">
-          Apply Slope Box-Smoothing
-        </v-btn>
-        <v-text-field
-          label="Number of points to smoother over(odd)"
-          v-model.number="numSlopeSmoothingPoints"
-        />
-      </div>
-      <div class="input-row">
-        <v-btn
-          @click="onSmoothValues"
-          :disabled="!canSmooth">
-          Apply Elevation Box-Smoothing
-        </v-btn>
-        <v-text-field
-          label="Number of points to smoother over(odd)"
-          v-model.number="numSmoothingPoints"
-        />
-      </div>
-      <div class="input-row">
-        <v-btn
-          @click="onSavitzyGolay"
-          :disabled="!canSmooth">
-          Apply Savitzky-Golay Smoothing
-        </v-btn>
-        <v-text-field
-          label="Window Size (odd)"
-          v-model.number="windowSize"
-        />
-        <v-text-field
-          label="Derivative"
-          v-model.number="derivative"
-        />
-        <v-text-field
-          label="Polynomial (1 to 5)"
-          v-model.number="polynomial"
-        />
-      </div>
-      <div class="input-row">
-        <v-btn
-          @click="onKalmanFilter"
-          :disabled="!canSmooth">
-          Apply Kalman Filter
-        </v-btn>
-        <v-text-field
-          label="Process Noise (R)"
-          v-model.number="kalmanR"
-        />
-        <v-text-field
-          label="Measurement Noise (Q)"
-          v-model.number="kalmanQ"
-        />
-        <v-checkbox
-          label="Use Delta Slope"
-          v-model="useDeltaSlope"
-        ></v-checkbox>
-      </div>
-      <div class="input-row">
-        <v-btn
-          @click="onSetSlopeRange"
-          :disabled="!canSmooth">
-          Apply Slope Range
-        </v-btn>
-        <v-text-field
-          label="Minimum Slope"
-          v-model.number="minSlope"
-        />
-        <v-text-field
-          label="Maximum Slope"
-          v-model.number="maxSlope"
-        />
-      </div>
-      <div class="input-row">
-        <v-btn
-          @click="onFlattenValues"
-          :disabled="!canSmooth">
-          Apply Flatten Values
-        </v-btn>
-        <v-text-field
-          label="Maximum Change In Slope Between Points:"
-          v-model.number="slopeDelta"
-        />
+        <div class="input-row">
+          <v-btn
+            @click="onSlopeSmoothing"
+            :disabled="!canSmooth">
+            Apply Slope Box-Smoothing
+          </v-btn>
+          <v-text-field
+            label="Number of points to smoother over(odd)"
+            v-model.number="numSlopeSmoothingPoints"
+          />
+        </div>
+        <div class="input-row">
+          <v-btn
+            @click="onSmoothValues"
+            :disabled="!canSmooth">
+            Apply Elevation Box-Smoothing
+          </v-btn>
+          <v-text-field
+            label="Number of points to smoother over(odd)"
+            v-model.number="numSmoothingPoints"
+          />
+        </div>
+        <div class="input-row">
+          <v-btn
+            @click="onSavitzyGolay"
+            :disabled="!canSmooth">
+            Apply Savitzky-Golay Smoothing
+          </v-btn>
+          <v-text-field
+            label="Window Size (odd)"
+            v-model.number="windowSize"
+          />
+          <v-text-field
+            label="Derivative"
+            v-model.number="derivative"
+          />
+          <v-text-field
+            label="Polynomial (1 to 5)"
+            v-model.number="polynomial"
+          />
+        </div>
+        <div class="input-row">
+          <v-btn
+            @click="onKalmanFilter"
+            :disabled="!canSmooth">
+            Apply Kalman Filter
+          </v-btn>
+          <v-text-field
+            label="Process Noise (R)"
+            v-model.number="kalmanR"
+          />
+          <v-text-field
+            label="Measurement Noise (Q)"
+            v-model.number="kalmanQ"
+          />
+          <v-checkbox
+            label="Use Delta Slope"
+            v-model="useDeltaSlope"
+          ></v-checkbox>
+        </div>
+        <div class="input-row">
+          <v-btn
+            @click="onSetSlopeRange"
+            :disabled="!canSmooth">
+            Apply Slope Range
+          </v-btn>
+          <v-text-field
+            label="Minimum Slope"
+            v-model.number="minSlope"
+          />
+          <v-text-field
+            label="Maximum Slope"
+            v-model.number="maxSlope"
+          />
+        </div>
+        <div class="input-row">
+          <v-btn
+            @click="onFlattenValues"
+            :disabled="!canSmooth">
+            Apply Flatten Values
+          </v-btn>
+          <v-text-field
+            label="Maximum Change In Slope Between Points:"
+            v-model.number="slopeDelta"
+          />
+        </div>
       </div>
       <div class="input-row">
         <v-btn
@@ -340,5 +342,8 @@ export default {
     margin: 20px
     .v-input__slot
       max-width: 600px
+
+  .save  .smoothing-algorithms
+    margin-left: 30px
 
 </style>

--- a/src/views/History.vue
+++ b/src/views/History.vue
@@ -80,26 +80,32 @@ export default {
       store.dispatch('redoOperations');
     },
     getOperationDescription(operation) {
+      let opDesc;
       switch (operation.name) {
         case 'smoothSlope': {
-          return `Slope Box Smoothing: Smoothed over ${operation.numberOfPoints} Points`;
+          opDesc = `Slope Box Smoothing: Smoothed over ${operation.numberOfPoints} Points`;
+          break;
         }
         case 'smooth': {
-          return `Elevation Box Smoothing: Smoothed over ${operation.numberOfPoints} Points`;
+          opDesc = `Elevation Box Smoothing: Smoothed over ${operation.numberOfPoints} Points`;
+          break;
         }
         case 'savitzkyGolay': {
-          return `Savitzky Golay Smoothing: Window Size: ${operation.windowSize}, Derivative: ${operation.derivative}, ` +
+          opDesc = `Savitzky Golay Smoothing: Window Size: ${operation.windowSize}, Derivative: ${operation.derivative}, ` +
               `Polynomial:  ${operation.polynomial}`;
+          break;
         }
         case 'kalmanFilter': {
-          return `Kalman Filter: R: ${operation.R}, Q: ${operation.Q}, Use Delta Slope:  ` +
-              (operation.useDeltaSlope ? 'true' : 'false');
+          opDesc = `Kalman Filter: R: ${operation.R}, Q: ${operation.Q}, Use Delta Slope: ${operation.useDeltaSlope}`;
+          break;
          }
         case 'slopeRange': {
-          return `Slope Range: Minimum Slope: ${operation.range.minSlope},  Maximum Slope: ${operation.range.maxSlope}`;
+          opDesc = `Slope Range: Minimum Slope: ${operation.range.minSlope}, Maximum Slope: ${operation.range.maxSlope}`;
+          break;
         }
         case 'flatten': {
-          return `Flatten Values:  Maximum Change in Slope Between Points:  ${operation.slopeDelta}`;
+          opDesc = `Flatten Values:  Maximum Change in Slope Between Points: ${operation.slopeDelta}`;
+          break;
         }
         case 'slopePercentage': {
           return `Slope Difficulty: Percentage slope change: ${operation.slopeShift}`;
@@ -107,14 +113,12 @@ export default {
         case 'elevate': {
           return `Elevate Values: Shift in metres: ${operation.metres}`;
         }
-        case 'restoreAscentDescent': {
-          return 'Restore ascent/descent';
-        }
         case 'updateTimeIntervals': {
           const timeShift = parseInt(1000.0 / (operation.timeShift / 100.0), 10);
           return `Time interval of each point is 1 second shifted by ${operation.timeShift} percent (${timeShift} ms)`;
         }
       }
+      return `${opDesc}, Maintain Elevations: ${operation.maintainElevations}`;
     }
   }
 };

--- a/src/views/History.vue
+++ b/src/views/History.vue
@@ -107,6 +107,9 @@ export default {
         case 'elevate': {
           return `Elevate Values: Shift in metres: ${operation.metres}`;
         }
+        case 'restoreAscentDescent': {
+          return 'Restore ascent/descent';
+        }
         case 'updateTimeIntervals': {
           const timeShift = parseInt(1000.0 / (operation.timeShift / 100.0), 10);
           return `Time interval of each point is 1 second shifted by ${operation.timeShift} percent (${timeShift} ms)`;


### PR DESCRIPTION
Adds a global option for all smoothing algorithms which adds post processing to keep the start point and end point elevations of the selection at their original values after smoothing.

This allows to keep tracks as close to the original as possible automagically.

<img width="743" height="794" alt="Screenshot 2026-01-15 at 16-51-56 Vue GPX Smoother" src="https://github.com/user-attachments/assets/d12145b1-a0c8-4de0-9c04-18f71c046cf9" />
